### PR TITLE
fix: add missing cwd to runScript spawn

### DIFF
--- a/bin/openutter.mjs
+++ b/bin/openutter.mjs
@@ -209,6 +209,7 @@ function runScript(scriptName, args) {
 
   const result = spawnSync(process.execPath, ["--import", "tsx", scriptPath, ...args], {
     stdio: "inherit",
+    cwd: pkgRoot,
   });
 
   if (result.error) {


### PR DESCRIPTION
Fixes #5

## Problem

`npx openutter join` fails with `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'` when run from any directory that does not have `tsx` in its `node_modules`.

## Root Cause

`runScript()` spawns Node with `--import tsx` but does not set `cwd: pkgRoot`. Node resolves `tsx` relative to the current working directory instead of the package root where `tsx` is actually installed.

## Fix

One-line change: add `cwd: pkgRoot` to the `spawnSync` options in `runScript()`, consistent with `runNodeCommand()` and `runPlaywrightCommand()` which already set this.

## Testing

Before fix:
```bash
cd /tmp && npx openutter join https://meet.google.com/abc --anon --bot-name "Bot"
# → ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'
```

After fix:
```bash
cd /tmp && npx openutter join https://meet.google.com/abc --anon --bot-name "Bot"
# → Works correctly (tsx resolved from package node_modules)
```